### PR TITLE
fix(backend): enforce DTO validation and bound deck joker count

### DIFF
--- a/apps/async-games-backend/src/app/domains/classic-card/classic-card.dto.ts
+++ b/apps/async-games-backend/src/app/domains/classic-card/classic-card.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsBoolean, IsInt, IsString } from 'class-validator';
+import { IsBoolean, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
 import { classicCardSuits } from './classic-card.interface';
 
 export class ClassicPlayingCardDTO {
@@ -50,9 +50,15 @@ export class ClassicPlayingCardDTO {
 }
 
 export class ClassicDeckOptionsDTO {
+  // Bound jokers to prevent unbounded allocation / DoS: a request such as
+  // { jokers: 1e9 } would otherwise loop a billion times building cards.
+  @IsOptional()
   @IsInt()
+  @Min(0)
+  @Max(8)
   jokers?: number;
 
+  @IsOptional()
   @IsBoolean()
   aceLow?: boolean;
 }

--- a/apps/async-games-backend/src/main.ts
+++ b/apps/async-games-backend/src/main.ts
@@ -3,7 +3,7 @@
  * This is only a minimal backend to get started.
  */
 
-import { Logger } from '@nestjs/common';
+import { Logger, ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AppModule } from './app/app.module';
@@ -12,6 +12,17 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   const globalPrefix = 'api';
   app.setGlobalPrefix(globalPrefix);
+  // Enforce class-validator DTOs at the request boundary (the documented
+  // "two-layer validation" Layer 1). whitelist strips unknown properties;
+  // forbidNonWhitelisted rejects them (→400); transform coerces payloads
+  // into the DTO classes so decorators like @IsInt actually run.
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    })
+  );
   const port = process.env.PORT || 3000;
 
   //add SwaggerModule on bootstrap()


### PR DESCRIPTION
## Summary
Fixes two HIGH-severity findings from the security review.

- **Missing global ValidationPipe** — registers `ValidationPipe({ whitelist, forbidNonWhitelisted, transform })` so the documented "two-layer validation" Layer 1 is actually enforced (previously every `class-validator` DTO decorator was silently ignored).
- **Unbounded `jokers` DoS** — adds `@Min(0) @Max(8) @IsOptional` to `ClassicDeckOptionsDTO.jokers`; `POST /api/card/deck { "jokers": 1e9 }` would otherwise loop a billion times building cards.

Backend tests pass (38) and the app builds.

> Rebase onto `main` after #17 (CI pipeline) merges so the new checks gate this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)